### PR TITLE
Add support of Slack web app

### DIFF
--- a/src/js/esarea.coffee
+++ b/src/js/esarea.coffee
@@ -1,4 +1,4 @@
-return if location.host.match(/qiita\.com|esa\.io|docbase\.io|pplog\.net|lvh\.me/)
+return if location.host.match(/qiita\.com|esa\.io|docbase\.io|pplog\.net|lvh\.me|slack\.com/)
 
 suggesting = null
 $(document).on 'keyup', 'textarea', (e) ->


### PR DESCRIPTION
Slackのwebアプリケーションでは `esarea` を無効にするための pull request です。

Slackだとmarkdownを使わないのと、主に絵文字の選択でタブを押すたびにインデントが増えていってしまうので追加しました。

よろしくお願いします。
