### PR TITLE
Add support for "mimemo.io"

### DIFF
--- a/src/js/esarea.coffee
+++ b/src/js/esarea.coffee
@@ -1,4 +1,4 @@
-return if location.host.match(/qiita\.com|esa\.io|docbase\.io|pplog\.net|lvh\.me|slack\.com/)
+return if location.host.match(/qiita\.com|esa\.io|docbase\.io|pplog\.net|lvh\.me|slack\.com|mimemo\.io/)
 
 suggesting = null
 $(document).on 'keyup', 'textarea', (e) ->


### PR DESCRIPTION
https://mimemo.io でesareaを無効にするための変更です。

mimemoでMarkdownの入力補助を独自で実装している分がesareaの機能とぶつかってしまうために無効にしました。

よろしくお願いします。
