### PR TITLE
`data-disable-esarea="true"` が設定されているtextareaにesareaを適用しない

### DIFF
--- a/src/js/esarea.coffee
+++ b/src/js/esarea.coffee
@@ -3,25 +3,30 @@ require('jquery.selection/src/jquery.selection.js')
 
 return if location.host.match(/qiita\.com|esa\.io|docbase\.io|pplog\.net|lvh\.me|slack\.com|mimemo\.io|kibe\.la|hackmd\.io/)
 
+textareaList = $('textarea:not([data-esarea-disabled="true"])')
+return if textareaList.length == 0
+
 suggesting = null
-$(document).on 'keyup', 'textarea', (e) ->
-  if location.host.match /github\.com/
-    suggesting = !!$('ul.suggestions:visible').length
-  else if location.host.match /idobata\.io/
-    suggesting = !!$('.atwho-view:visible').length
-  return
 
-$(document).on 'keydown', 'textarea', (e) ->
-  return if suggesting
+textareaList.each ->
+  $(this).keyup (e) ->
+    if location.host.match /github\.com/
+      suggesting = !!$('ul.suggestions:visible').length
+    else if location.host.match /idobata\.io/
+      suggesting = !!$('.atwho-view:visible').length
+    return
 
-  switch (e.which || e.keyCode)
-    when 9
-      handleTabKey(e)
-    when 13
-      handleEnterKey(e)
-    when 32
-      handleSpaceKey(e)
-  return
+  $(this).keydown (e) ->
+    return if suggesting
+
+    switch (e.which || e.keyCode)
+      when 9
+        handleTabKey(e)
+      when 13
+        handleEnterKey(e)
+      when 32
+        handleSpaceKey(e)
+    return
 
 handleTabKey = (e) ->
   e.preventDefault()


### PR DESCRIPTION
Resolve #19 

[savanna](https://savanna.io/) で esareaをインストールしていないユーザーにもesareaと同様のmarkdown編集機能を提供するため、esareaのコードをベースに作成した[esalike](https://github.com/willnet-inc/esalike) を開発しています。

現在、同じtextareaでesalikeとesareaの機能が競合すると以下の動画のように想定しない挙動を示します。

https://user-images.githubusercontent.com/12929/212534496-45279566-7013-403e-8f03-16ec0b9d77d8.mov

この問題を回避するため、esalike側でesareaがインストールされているかを検出する方法がないかいくつかのアプローチを調査したのですが、いずれもesarea側での改修が必要でした。

そのため、本PRではissueに上がっていた #19 を実装することでesalike もしくはその他のJavaScriptプログラムでesareaがインストールされていることを検知し、想定しない挙動が発生するのを回避できるようにしたいと考えています。

本PRの動作確認にはesalikeの以下のPRに含まれる `esarea_test.html` を利用できます。

[Do not apply esalike's keyhandlers when \`data\-esarea\-disabled="true"\` is not set by masa\-iwasaki · Pull Request \#10 · willnet\-inc/esalike](https://github.com/willnet-inc/esalike/pull/10)

```bash
npm install
npm run dev # Visit http://localhost:3000/esarea_test.html
```